### PR TITLE
change dependency constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/openEPC/tss2-rs"
 license = "Apache-2.0"
 
 [build-dependencies]
-bindgen = "0"
+bindgen = "0.60"
 
 [features]
 sys = []

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tss2-rs = "0"
+tss2-rs = "0.1"
 ```
 
 Import necessary types and functions and use as you would do with tpm2-tss.


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.